### PR TITLE
ci: fix monorepo release workflows

### DIFF
--- a/.github/actions/prepare-release-env/action.yml
+++ b/.github/actions/prepare-release-env/action.yml
@@ -1,0 +1,58 @@
+name: 'Prepare Release Environment'
+description: 'Prepare release environment variables and matrix'
+
+inputs:
+  github_ref:
+    description: 'GitHub reference'
+    required: true
+    default: ${{ github.ref }}
+
+outputs:
+  MAJOR_RELEASE_VERSION:
+    description: 'Major release version'
+    value: ${{ steps.env-vars.outputs.MAJOR_RELEASE_VERSION }}
+  RELEASE_VERSION:
+    description: 'Release version'
+    value: ${{ steps.env-vars.outputs.RELEASE_VERSION }}
+  TRIMMED_RELEASE_VERSION:
+    description: 'Trimmed release version'
+    value: ${{ steps.env-vars.outputs.TRIMMED_RELEASE_VERSION }}
+  MATRIX:
+    description: 'Generated matrix'
+    value: ${{ steps.generate-matrix.outputs.matrix }}
+
+runs:
+  using: 'composite'
+  steps:
+    - name: checkout code
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 1
+        path: go/src/open-cluster-management.io/lab
+
+    - name: get release version
+      shell: bash
+      run: |
+        echo "RELEASE_VERSION=${GITHUB_REF##*/}" >> $GITHUB_ENV
+      env:
+        GITHUB_REF: ${{ inputs.github_ref }}
+
+    - name: get major release version
+      shell: bash
+      run: |
+        echo "MAJOR_RELEASE_VERSION=${RELEASE_VERSION%.*}" >> $GITHUB_ENV
+        echo "TRIMMED_RELEASE_VERSION=${RELEASE_VERSION#v}" >> $GITHUB_ENV
+
+    - name: set outputs
+      id: env-vars
+      shell: bash
+      run: |
+        echo "MAJOR_RELEASE_VERSION=${MAJOR_RELEASE_VERSION}" >> $GITHUB_OUTPUT
+        echo "RELEASE_VERSION=${RELEASE_VERSION}" >> $GITHUB_OUTPUT
+        echo "TRIMMED_RELEASE_VERSION=${TRIMMED_RELEASE_VERSION}" >> $GITHUB_OUTPUT
+
+    - name: generate matrix
+      id: generate-matrix
+      uses: ./go/src/open-cluster-management.io/lab/.github/actions/generate-repo-matrix
+      with:
+        repoRoot: go/src/open-cluster-management.io/lab 

--- a/.github/actions/prepare-release-env/action.yml
+++ b/.github/actions/prepare-release-env/action.yml
@@ -1,24 +1,24 @@
-name: 'Prepare Release Environment'
-description: 'Prepare release environment variables and matrix'
+name: Prepare Release Environment
+description: Prepare release environment variables and repository matrix
 
 inputs:
   github_ref:
-    description: 'GitHub reference'
+    description: GitHub reference
     required: true
     default: ${{ github.ref }}
 
 outputs:
   MAJOR_RELEASE_VERSION:
-    description: 'Major release version'
+    description: Major release version
     value: ${{ steps.env-vars.outputs.MAJOR_RELEASE_VERSION }}
   RELEASE_VERSION:
-    description: 'Release version'
+    description: Release version
     value: ${{ steps.env-vars.outputs.RELEASE_VERSION }}
   TRIMMED_RELEASE_VERSION:
-    description: 'Trimmed release version'
+    description: Trimmed release version
     value: ${{ steps.env-vars.outputs.TRIMMED_RELEASE_VERSION }}
   MATRIX:
-    description: 'Generated matrix'
+    description: Repository matrix
     value: ${{ steps.generate-matrix.outputs.matrix }}
 
 runs:
@@ -55,4 +55,4 @@ runs:
       id: generate-matrix
       uses: ./go/src/open-cluster-management.io/lab/.github/actions/generate-repo-matrix
       with:
-        repoRoot: go/src/open-cluster-management.io/lab 
+        repoRoot: go/src/open-cluster-management.io/lab

--- a/.github/actions/prepare-release-env/action.yml
+++ b/.github/actions/prepare-release-env/action.yml
@@ -24,12 +24,6 @@ outputs:
 runs:
   using: 'composite'
   steps:
-    - name: checkout code
-      uses: actions/checkout@v4
-      with:
-        fetch-depth: 1
-        path: go/src/open-cluster-management.io/lab
-
     - name: get release version
       shell: bash
       run: |

--- a/.github/workflows/chart-upload.yml
+++ b/.github/workflows/chart-upload.yml
@@ -12,31 +12,16 @@ jobs:
     name: prepare release env
     runs-on: ubuntu-latest
     steps:
-      - name: checkout code
-        uses: actions/checkout@v4
+      - name: prepare release environment
+        id: prepare-env
+        uses: ./go/src/open-cluster-management.io/lab/.github/actions/prepare-release-env
         with:
-          fetch-depth: 1
-          path: go/src/open-cluster-management.io/lab
-
-      - name: get release version
-        run: |
-          echo "RELEASE_VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
-
-      - name: get major release version
-        run: |
-          echo "MAJOR_RELEASE_VERSION=${RELEASE_VERSION%.*}" >> $GITHUB_ENV
-          echo "TRIMMED_RELEASE_VERSION=${RELEASE_VERSION#v}" >> $GITHUB_ENV
-
-      - name: generate matrix
-        id: generate-matrix
-        uses: ./go/src/open-cluster-management.io/lab/.github/actions/generate-repo-matrix
-        with:
-          repoRoot: go/src/open-cluster-management.io/lab
+          github_ref: ${{ github.ref }}
     outputs:
-      MAJOR_RELEASE_VERSION: ${{ env.MAJOR_RELEASE_VERSION }}
-      RELEASE_VERSION: ${{ env.RELEASE_VERSION }}
-      TRIMMED_RELEASE_VERSION: ${{ env.TRIMMED_RELEASE_VERSION }}
-      MATRIX: ${{ steps.generate-matrix.outputs.matrix }}
+      MAJOR_RELEASE_VERSION: ${{ steps.prepare-env.outputs.MAJOR_RELEASE_VERSION }}
+      RELEASE_VERSION: ${{ steps.prepare-env.outputs.RELEASE_VERSION }}
+      TRIMMED_RELEASE_VERSION: ${{ steps.prepare-env.outputs.TRIMMED_RELEASE_VERSION }}
+      MATRIX: ${{ steps.prepare-env.outputs.MATRIX }}
 
   upload:
     name: upload

--- a/.github/workflows/chart-upload.yml
+++ b/.github/workflows/chart-upload.yml
@@ -12,6 +12,12 @@ jobs:
     name: prepare release env
     runs-on: ubuntu-latest
     steps:
+      - name: checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+          path: go/src/open-cluster-management.io/lab
+
       - name: prepare release environment
         id: prepare-env
         uses: ./go/src/open-cluster-management.io/lab/.github/actions/prepare-release-env

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,12 @@ jobs:
     name: prepare release env
     runs-on: ubuntu-latest
     steps:
+      - name: checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+          path: go/src/open-cluster-management.io/lab
+
       - name: prepare release environment
         id: prepare-env
         uses: ./go/src/open-cluster-management.io/lab/.github/actions/prepare-release-env

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,31 +23,16 @@ jobs:
     name: prepare release env
     runs-on: ubuntu-latest
     steps:
-      - name: checkout code
-        uses: actions/checkout@v4
+      - name: prepare release environment
+        id: prepare-env
+        uses: ./go/src/open-cluster-management.io/lab/.github/actions/prepare-release-env
         with:
-          fetch-depth: 1
-          path: go/src/open-cluster-management.io/lab
-
-      - name: get release version
-        run: |
-          echo "RELEASE_VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
-
-      - name: get major release version
-        run: |
-          echo "MAJOR_RELEASE_VERSION=${RELEASE_VERSION%.*}" >> $GITHUB_ENV
-          echo "TRIMMED_RELEASE_VERSION=${RELEASE_VERSION#v}" >> $GITHUB_ENV
-
-      - name: generate matrix
-        id: generate-matrix
-        uses: ./go/src/open-cluster-management.io/lab/.github/actions/generate-repo-matrix
-        with:
-          repoRoot: go/src/open-cluster-management.io/lab
+          github_ref: ${{ github.ref }}
     outputs:
-      MAJOR_RELEASE_VERSION: ${{ env.MAJOR_RELEASE_VERSION }}
-      RELEASE_VERSION: ${{ env.RELEASE_VERSION }}
-      TRIMMED_RELEASE_VERSION: ${{ env.TRIMMED_RELEASE_VERSION }}
-      MATRIX: ${{ steps.generate-matrix.outputs.matrix }}
+      MAJOR_RELEASE_VERSION: ${{ steps.prepare-env.outputs.MAJOR_RELEASE_VERSION }}
+      RELEASE_VERSION: ${{ steps.prepare-env.outputs.RELEASE_VERSION }}
+      TRIMMED_RELEASE_VERSION: ${{ steps.prepare-env.outputs.TRIMMED_RELEASE_VERSION }}
+      MATRIX: ${{ steps.prepare-env.outputs.MATRIX }}
 
   release:
     name: release

--- a/.github/workflows/releaseimage.yml
+++ b/.github/workflows/releaseimage.yml
@@ -24,30 +24,15 @@ jobs:
     name: prepare release env
     runs-on: ubuntu-latest
     steps:
-      - name: checkout code
-        uses: actions/checkout@v4
+      - name: prepare release environment
+        id: prepare-env
+        uses: ./go/src/open-cluster-management.io/lab/.github/actions/prepare-release-env
         with:
-          fetch-depth: 1
-          path: go/src/open-cluster-management.io/lab
-
-      - name: get release version
-        run: |
-          echo "RELEASE_VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
-
-      - name: get major release version
-        run: |
-          echo "MAJOR_RELEASE_VERSION=${RELEASE_VERSION%.*}" >> $GITHUB_ENV
-          echo "TRIMMED_RELEASE_VERSION=${RELEASE_VERSION#v}" >> $GITHUB_ENV
-
-      - name: generate matrix
-        id: generate-matrix
-        uses: ./go/src/open-cluster-management.io/lab/.github/actions/generate-repo-matrix
-        with:
-          repoRoot: go/src/open-cluster-management.io/lab
+          github_ref: ${{ github.ref }}
     outputs:
-      MAJOR_RELEASE_VERSION: ${{ env.MAJOR_RELEASE_VERSION }}
-      RELEASE_VERSION: ${{ env.RELEASE_VERSION }}
-      MATRIX: ${{ steps.generate-matrix.outputs.matrix }}
+      MAJOR_RELEASE_VERSION: ${{ steps.prepare-env.outputs.MAJOR_RELEASE_VERSION }}
+      RELEASE_VERSION: ${{ steps.prepare-env.outputs.RELEASE_VERSION }}
+      MATRIX: ${{ steps.prepare-env.outputs.MATRIX }}
 
   images:
     name: images

--- a/.github/workflows/releaseimage.yml
+++ b/.github/workflows/releaseimage.yml
@@ -24,6 +24,12 @@ jobs:
     name: prepare release env
     runs-on: ubuntu-latest
     steps:
+      - name: checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+          path: go/src/open-cluster-management.io/lab
+
       - name: prepare release environment
         id: prepare-env
         uses: ./go/src/open-cluster-management.io/lab/.github/actions/prepare-release-env

--- a/.github/workflows/releaseimage.yml
+++ b/.github/workflows/releaseimage.yml
@@ -47,7 +47,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 1
-          path: go/src/open-cluster-management.io/lab
+          path: go/src/open-cluster-management.io/lab/${{ matrix.repository }}
 
       - name: install Go
         uses: actions/setup-go@v5
@@ -86,7 +86,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 1
-          path: go/src/open-cluster-management.io/lab
+          path: go/src/open-cluster-management.io/lab/${{ matrix.repository }}
 
       - name: create
         run: |

--- a/README.md
+++ b/README.md
@@ -53,6 +53,10 @@ All projects must define the following `make` targets:
 - `check-diff`: Perform any automated formatting, Helm chart README updates, manifest generation, etc. Return a non-zero exit code if a git diff is produced.
 - `test-e2e`: Invoke end-to-end tests and return an exit code accordingly.
 - `test-unit`: Invoke unit tests and return an exit code accordingly.
+- `images`: Build all container images.
+- `image-push`: Push all container images.
+- `image-manifest`: Create multi-architecture manifests for all images.
+- `image-manifest-annotate`: Annotate multi-architecture manifests for all images.
 
 #### Dockerfiles
 


### PR DESCRIPTION
- Trim until final `/` when detecting `RELEASE_VERSION`. This strips repository names from release tags, e.g. `fleetconfig-controller/v0.1.0` -> `v0.1.0`
- Set work dir to repository being released during `releaseimage` workflow so that `make images`, etc. works