### PR TITLE
ci: fix issues with monorepo release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -104,4 +104,4 @@ jobs:
           draft: true
           generate_release_notes: true
           files: |
-            /home/runner/work/ocm/ocm/go/src/open-cluster-management.io/lab/release/*.tgz
+            /home/runner/work/lab/lab/go/src/open-cluster-management.io/lab/release/*.tgz

--- a/.github/workflows/releaseimage.yml
+++ b/.github/workflows/releaseimage.yml
@@ -9,7 +9,7 @@ env:
   # Common versions
   GO_VERSION: '1.24'
   GO_REQUIRED_MIN_VERSION: ''
-  GOPATH: '/home/runner/work/ocm/ocm/go'
+  GOPATH: '/home/runner/work/lab/lab/go'
   GITHUB_REF: ${{ github.ref }}
 
 defaults:

--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,6 @@ go.work.sum
 .devspace/
 .idea/
 .vscode/
+venv/
+*__pycache__/
+requirements.txt

--- a/fleetconfig-controller/Makefile
+++ b/fleetconfig-controller/Makefile
@@ -28,7 +28,7 @@ $(foreach flavour,$(IMAGE_FLAVOURS),\
 image-push:
 	$(foreach flavour,$(IMAGE_FLAVOURS),\
 		$(eval IMAGE_REPO := $(word 1,$(subst :, ,$(flavour)))) \
-		docker push $(IMAGE_REGISTRY)/$(IMAGE_REPO):$(IMAGE_TAG) \
+		docker push $(IMAGE_REGISTRY)/$(IMAGE_REPO):$(IMAGE_TAG); \
 	)
 
 .PHONY: image-manifest
@@ -36,7 +36,7 @@ image-manifest:
 	$(foreach flavour,$(IMAGE_FLAVOURS),\
 		$(eval IMAGE_REPO := $(word 1,$(subst :, ,$(flavour)))) \
 		$(eval IMAGE := $(IMAGE_REGISTRY)/$(IMAGE_REPO):$(IMAGE_TAG)) \
-		docker manifest create $(IMAGE) $(IMAGE)-amd64 --amd64 $(IMAGE)-arm64 --arm64 \
+		docker manifest create $(IMAGE) $(IMAGE)-amd64 --amd64 $(IMAGE)-arm64 --arm64; \
 	)
 
 .PHONY: image-manifest-annotate
@@ -44,8 +44,8 @@ image-manifest-annotate:
 	$(foreach flavour,$(IMAGE_FLAVOURS),\
 		$(eval IMAGE_REPO := $(word 1,$(subst :, ,$(flavour)))) \
 		$(eval IMAGE := $(IMAGE_REGISTRY)/$(IMAGE_REPO):$(IMAGE_TAG)) \
-		docker manifest annotate $(IMAGE) --arch amd64 $(IMAGE)-amd64 \
-		docker manifest annotate $(IMAGE) --arch arm64 $(IMAGE)-arm64 \
+		docker manifest annotate $(IMAGE) --arch amd64 $(IMAGE)-amd64; \
+		docker manifest annotate $(IMAGE) --arch arm64 $(IMAGE)-arm64; \
 	)
 
 ##@ Generation Targets

--- a/hack/changelog.py
+++ b/hack/changelog.py
@@ -1,4 +1,5 @@
 import sys
+import os
 
 from enum import Enum
 from github import Github
@@ -54,7 +55,10 @@ def section_if_present(changes: [], pr_title):
 
 if __name__ == '__main__':
     args = sys.argv[1:]
-    auth = Auth.Token(args[0])
+    token = args[0]
+    if len(token) == 0:
+        token = os.getenv("GITHUB_TOKEN")
+    auth = Auth.Token(token)
     repo_name = args[1]
     release_tag = args[2]
     g = Github(auth=auth)
@@ -90,7 +94,7 @@ if __name__ == '__main__':
         if pr.number == last_release_pr:
             break
         if pr.is_merged():
-            if repo_name not in pr.labels:
+            if repo_name not in [l.name for l in pr.labels]:
                 continue
             prtype, title = pr_type_from_title(pr.title)
             if prtype == PRType.FeaturePR:
@@ -115,5 +119,6 @@ if __name__ == '__main__':
     section_if_present(bugs, ":bug: Bug Fixes")
     section_if_present(docs, ":book: Documentation")
     section_if_present(infras, ":seedling: Infra & Such")
+    section_if_present(uncategorized, ":hammer_and_wrench: Uncategorized")
     print("")
     print("Thanks to all our contributors!*")


### PR DESCRIPTION
- Fix lingering paths using `ocm` instead of `labs`
- Fix filtering of PRs by label in `changelog.py`
- Fix image release targets for `fleetconfig-controller`