### PR TITLE
🌱 enable manual releases via workflow dispatch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,7 @@ on:
   push:
     tags:
       - '*/v*.*.*'
+  workflow_dispatch:
 
 env:
   GITHUB_REF: ${{ github.ref }}

--- a/.github/workflows/releaseimage.yml
+++ b/.github/workflows/releaseimage.yml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
       - '*/v*.*.*'
+  workflow_dispatch:
 
 env:
   # Common versions


### PR DESCRIPTION
Pushing tags to this repo isn't triggering the `release` and `releaseimage` workflows right now, due to Github issues. Therefore it would be nice if we could do it manually.