### PR TITLE
🐛 set owner meta on addon resources to prevent deleting out-of-band addons

### DIFF
--- a/fleetconfig-controller/api/v1alpha1/constants.go
+++ b/fleetconfig-controller/api/v1alpha1/constants.go
@@ -1,5 +1,7 @@
 package v1alpha1
 
+import "k8s.io/apimachinery/pkg/labels"
+
 const (
 	// FleetConfigFinalizer is the finalizer for FleetConfig cleanup.
 	FleetConfigFinalizer = "fleetconfig.open-cluster-management.io/cleanup"
@@ -58,6 +60,9 @@ const (
 const (
 	// LabelManagedClusterType is the label key for the managed cluster type.
 	LabelManagedClusterType = "fleetconfig.open-cluster-management.io/managedClusterType"
+
+	// LabelAddOnManagedBy is the label key for the lifecycle manager of an add-on resource.
+	LabelAddOnManagedBy = "addon.open-cluster-management.io/managedBy"
 )
 
 // Registration driver types
@@ -83,3 +88,12 @@ const (
 
 // AllowedAddonURLSchemes are the URL schemes which can be used to provide manifests for configuring addons.
 var AllowedAddonURLSchemes = []string{"http", "https"}
+
+var (
+	// ManagedByLabels are labeles applies to resources to denote that fleetconfig-controller is managing the lifecycle.
+	ManagedByLabels = map[string]string{
+		LabelAddOnManagedBy: "fleetconfig-controller",
+	}
+	// ManagedBySelector is a label selector for filtering add-on resources managed fleetconfig-controller.
+	ManagedBySelector = labels.SelectorFromSet(labels.Set(ManagedByLabels))
+)

--- a/fleetconfig-controller/api/v1alpha1/validation.go
+++ b/fleetconfig-controller/api/v1alpha1/validation.go
@@ -184,7 +184,7 @@ func getManagedClusterAddOns(ctx context.Context) ([]addonv1alpha1.ManagedCluste
 	if err != nil {
 		return nil, fmt.Errorf("failed to create addon clientset: %w", err)
 	}
-	addonList, err := addonClientset.AddonV1alpha1().ManagedClusterAddOns(metav1.NamespaceAll).List(ctx, metav1.ListOptions{})
+	addonList, err := addonClientset.AddonV1alpha1().ManagedClusterAddOns(metav1.NamespaceAll).List(ctx, metav1.ListOptions{LabelSelector: ManagedBySelector.String()})
 	if err != nil {
 		return nil, fmt.Errorf("failed to list ManagedClusterAddOns: %w", err)
 	}

--- a/fleetconfig-controller/internal/controller/spoke.go
+++ b/fleetconfig-controller/internal/controller/spoke.go
@@ -49,6 +49,10 @@ func handleSpokes(ctx context.Context, kClient client.Client, fc *v1alpha1.Fleet
 	if err != nil {
 		return err
 	}
+	addonClient, err := common.AddOnClient(hubKubeconfig)
+	if err != nil {
+		return err
+	}
 
 	// clean up deregistered spokes
 	joinedSpokes := make([]v1alpha1.JoinedSpoke, 0)
@@ -165,7 +169,7 @@ func handleSpokes(ctx context.Context, kClient client.Client, fc *v1alpha1.Fleet
 			}
 		}
 
-		enabledAddons, err := handleSpokeAddons(ctx, spoke, fc)
+		enabledAddons, err := handleSpokeAddons(ctx, addonClient, spoke, fc)
 		allEnabledAddons[i] = enabledAddons
 		if err != nil {
 			msg := fmt.Sprintf("failed to enable addons for spoke cluster %s: %s", spoke.Name, err.Error())


### PR DESCRIPTION
### Description

This PR:
- adds a `"addon.open-cluster-management.io/managedBy": fleetconfig-controller` label to any `ClusterManagementAddOn`, `AddOnTemplate` and `ManagedClusterAddOn` that is created by FCC
- uses this label to filter the resources when deciding what to delete/disable

This will prevent accidentally deleting addons that are created either manually (helm charts, etc), or using `clusteradm`.

### Sanity testing

- Created 2 kind clusters.
- Installed FCC, created a FleetConfig to register 1 spoke
- Followed https://github.com/open-cluster-management-io/ocm/tree/main/solutions/argocd-agent to install ArgoCD agent addon.
- Verified that prior to these changes, the addon was deleted on the next FC reconcile
- Verified that after the changes, the addon is not deleted by FCC and can be used as expected.

Note: argocd agent addon does not seem to be designed to work with a hub-as-spoke cluster, so it's best to not register the hub as a spoke, or modify the placement to not target the hub-as-spoke