### PR TITLE
chore: update repo go toolchain to 1.26

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6.2.0
         with:
-          go-version: 1.24.4
+          go-version: 1.26.1
 
       - name: Test E2E
         run: |

--- a/.github/workflows/releaseimage.yml
+++ b/.github/workflows/releaseimage.yml
@@ -8,7 +8,7 @@ on:
 
 env:
   # Common versions
-  GO_VERSION: '1.24'
+  GO_VERSION: '1.26'
   GO_REQUIRED_MIN_VERSION: ''
   GOPATH: '/home/runner/work/lab/lab/go'
   GITHUB_REF: ${{ github.ref }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v5
         with:
-          go-version: 1.24.4
+          go-version: 1.26.1
           # See: https://github.com/actions/setup-go/issues/424
           # go-version-file: go.work
           cache-dependency-path: "**/go.sum"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Go toolchain version across CI/CD pipelines from 1.24 to 1.26.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->