### PR TITLE
fixing hub accepted not showing properly in the dashboard

### DIFF
--- a/dashboard/apiserver/pkg/handlers/clusters.go
+++ b/dashboard/apiserver/pkg/handlers/clusters.go
@@ -72,6 +72,9 @@ func convertManagedClusterToCluster(managedCluster clusterv1.ManagedCluster) mod
 		Status:            "Unknown",
 	}
 
+	// Extract cluster is hub accepted
+	cluster.HubAccepted = managedCluster.Spec.HubAcceptsClient
+
 	// Extract Kubernetes version
 	if managedCluster.Status.Version.Kubernetes != "" {
 		cluster.Version = managedCluster.Status.Version.Kubernetes


### PR DESCRIPTION
Fixing the ui when displaying the list of managed clusters. Even if the hub accepted the clusters, the `Hub Accepted` parameter was always showing `Not Accepted`.

With the fix :

<img width="1867" height="946" alt="hub_accepted_fix" src="https://github.com/user-attachments/assets/6c84a938-e29a-4894-ad50-4be9d03192ce" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Cluster API responses now include a hub acceptance indicator, showing whether the hub accepts incoming client connections for each cluster. This status is returned with cluster details in both list and single-cluster views, improving visibility into cluster connectivity and acceptance state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->