### PR TITLE
fix: group replace blocks together to get around renovate's extractor bug

### DIFF
--- a/fleetconfig-controller/go.mod
+++ b/fleetconfig-controller/go.mod
@@ -141,6 +141,8 @@ require (
 )
 
 replace (
+	helm.sh/helm/v3 => helm.sh/helm/v3 v3.18.5
+
 	k8s.io/api => k8s.io/api v0.34.1
 	k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.34.1
 	k8s.io/apimachinery => k8s.io/apimachinery v0.34.1
@@ -167,5 +169,3 @@ replace (
 	k8s.io/pod-security-admission => k8s.io/pod-security-admission v0.34.1
 	k8s.io/sample-apiserver => k8s.io/sample-apiserver v0.34.1
 )
-
-replace helm.sh/helm/v3 => helm.sh/helm/v3 v3.18.5

--- a/fleetconfig-controller/go.mod
+++ b/fleetconfig-controller/go.mod
@@ -142,7 +142,6 @@ require (
 
 replace (
 	helm.sh/helm/v3 => helm.sh/helm/v3 v3.18.5
-
 	k8s.io/api => k8s.io/api v0.34.1
 	k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.34.1
 	k8s.io/apimachinery => k8s.io/apimachinery v0.34.1

--- a/fleetconfig-controller/vendor/modules.txt
+++ b/fleetconfig-controller/vendor/modules.txt
@@ -1122,6 +1122,7 @@ sigs.k8s.io/structured-merge-diff/v6/value
 ## explicit; go 1.22
 sigs.k8s.io/yaml
 sigs.k8s.io/yaml/goyaml.v3
+# helm.sh/helm/v3 => helm.sh/helm/v3 v3.18.5
 # k8s.io/api => k8s.io/api v0.34.1
 # k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.34.1
 # k8s.io/apimachinery => k8s.io/apimachinery v0.34.1
@@ -1147,4 +1148,3 @@ sigs.k8s.io/yaml/goyaml.v3
 # k8s.io/mount-utils => k8s.io/mount-utils v0.34.1
 # k8s.io/pod-security-admission => k8s.io/pod-security-admission v0.34.1
 # k8s.io/sample-apiserver => k8s.io/sample-apiserver v0.34.1
-# helm.sh/helm/v3 => helm.sh/helm/v3 v3.18.5


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Reformatted dependency configuration for improved clarity and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->