### PR TITLE
chore: dont trigger planner on pull_request_target

### DIFF
--- a/.github/workflows/planner.yml
+++ b/.github/workflows/planner.yml
@@ -2,7 +2,6 @@ name: Planner
 
 on:
   pull_request:
-  pull_request_target:
     types: [opened, labeled, unlabeled, reopened, synchronize, ready_for_review]
   workflow_dispatch:
 


### PR DESCRIPTION
Using `pull_request_target` in a public repo is a security risk. `pull_request_target` exposes the base repo's context to any pull request from a forked repo. This includes secrets such as the default `GITHUB_TOKEN` with write permissions. `pull_request` is the safe option to use for a public repo. Since the planner workflow does not rely on any secrets, this should have no side effects.

An example of how this could have been exploited:

- Attacker forks the repo
- Attacker makes a dummy change to a file that would cause the Planner to be triggered (for example adding a constant to the fleetconfig-controller API package)
- Attacker modifies one of the checks executed by the Planner to perform a malicious action (for example updating `make check-diff` to execute a script that exfiltrates all environment variables)
- Attacker opens a pull request from their fork against the base repo
- Their arbitrary code is executed with unrestricted access to GHA secrets.

Having both `pull_request` and `pull_request_target` triggers is also redundant, and has been causing duplicate tests to run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated pull request validation workflow configuration to streamline CI/CD processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->