### PR TITLE
dashboard - pin pnpm to v9 in Dockerfile.ui to fix UI image build

### DIFF
--- a/dashboard/Dockerfile.ui
+++ b/dashboard/Dockerfile.ui
@@ -9,7 +9,7 @@ COPY package*.json ./
 COPY pnpm-lock.yaml ./
 
 # Install dependencies
-RUN npm install -g pnpm && pnpm install --frozen-lockfile
+RUN npm install -g pnpm@9 && pnpm install --frozen-lockfile
 
 # Copy source code
 COPY . .


### PR DESCRIPTION
pnpm v10 changed defaults to fail the install when build scripts are ignored. esbuild (a transitive dependency of vite) triggers this, so `make docker-build-ui` and `make docker-build-local-ui` now exit 1 with `ERR_PNPM_IGNORED_BUILDS` whenever the latest pnpm is pulled.

Pin to pnpm v9 to restore the prior install behavior. A follow-up can move to v10 with explicit `pnpm.onlyBuiltDependencies` config.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build process dependencies to ensure consistent and reliable builds.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/open-cluster-management-io/lab/pull/190?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->