### PR TITLE
🐛 defer hub TLS temp-file cleanup at clusteradm exec scope

### DIFF
--- a/fleetconfig-controller/internal/controller/v1beta1/spoke_handler.go
+++ b/fleetconfig-controller/internal/controller/v1beta1/spoke_handler.go
@@ -1011,7 +1011,14 @@ func effectiveGRPCJoinServerAndCA(hub *v1beta1.Hub) (server, ca string, err erro
 
 // appendJoinSpokeTransportAndAuthArgs appends hub endpoint, hub TLS, registration drivers, hosted-mode kubeconfig,
 // proxy, and addon-kubeclient flags for clusteradm join.
-func (r *SpokeReconciler) appendJoinSpokeTransportAndAuthArgs(ctx context.Context, joinArgs []string, spoke *v1beta1.Spoke, hub *v1beta1.Hub, tokenMeta *tokenMeta) ([]string, error) {
+func (r *SpokeReconciler) appendJoinSpokeTransportAndAuthArgs(ctx context.Context, joinArgs []string, spoke *v1beta1.Spoke, hub *v1beta1.Hub, tokenMeta *tokenMeta) ([]string, func(), error) {
+	var cleanups []func()
+	cleanup := func() {
+		for _, c := range cleanups {
+			c()
+		}
+	}
+
 	// Use hub API server from spec if provided and not forced to use internal endpoint,
 	// otherwise fall back to the hub API server from the tokenMeta
 	if hub.Spec.APIServer != "" && !spoke.Spec.Klusterlet.ForceInternalEndpointLookup {
@@ -1023,10 +1030,10 @@ func (r *SpokeReconciler) appendJoinSpokeTransportAndAuthArgs(ctx context.Contex
 	if hub.Spec.Ca != "" {
 		caFile, caCleanup, err := file.TmpFile([]byte(hub.Spec.Ca), "ca")
 		if caCleanup != nil {
-			defer caCleanup()
+			cleanups = append(cleanups, caCleanup)
 		}
 		if err != nil {
-			return nil, fmt.Errorf("failed to write hub CA to disk: %w", err)
+			return nil, cleanup, fmt.Errorf("failed to write hub CA to disk: %w", err)
 		}
 		joinArgs = append([]string{fmt.Sprintf("--ca-file=%s", caFile)}, joinArgs...)
 	}
@@ -1049,14 +1056,14 @@ func (r *SpokeReconciler) appendJoinSpokeTransportAndAuthArgs(ctx context.Contex
 	if hub.Spec.RegistrationAuth.Driver == v1beta1.GRPCRegistrationDriver {
 		grpcServer, grpcCA, err := effectiveGRPCJoinServerAndCA(hub)
 		if err != nil {
-			return nil, err
+			return nil, cleanup, err
 		}
 		grpcCAFile, grpcCACleanup, err := file.TmpFile([]byte(grpcCA), "grpc-ca")
 		if grpcCACleanup != nil {
-			defer grpcCACleanup()
+			cleanups = append(cleanups, grpcCACleanup)
 		}
 		if err != nil {
-			return nil, fmt.Errorf("failed to write gRPC CA to disk: %w", err)
+			return nil, cleanup, fmt.Errorf("failed to write gRPC CA to disk: %w", err)
 		}
 		joinArgs = append(joinArgs,
 			fmt.Sprintf("--registration-auth=%s", v1beta1.GRPCRegistrationDriver),
@@ -1071,14 +1078,14 @@ func (r *SpokeReconciler) appendJoinSpokeTransportAndAuthArgs(ctx context.Contex
 		)
 		raw, err := kube.KubeconfigFromSecretOrCluster(ctx, r.Client, spoke.Spec.Klusterlet.ManagedClusterKubeconfig, spoke.Namespace)
 		if err != nil {
-			return nil, err
+			return nil, cleanup, err
 		}
 		mgdKcfg, mgdKcfgCleanup, err := file.TmpFile(raw, "kubeconfig")
 		if mgdKcfgCleanup != nil {
-			defer mgdKcfgCleanup()
+			cleanups = append(cleanups, mgdKcfgCleanup)
 		}
 		if err != nil {
-			return nil, fmt.Errorf("failed to write managedClusterKubeconfig to disk: %w", err)
+			return nil, cleanup, fmt.Errorf("failed to write managedClusterKubeconfig to disk: %w", err)
 		}
 		joinArgs = append(joinArgs, "--managed-cluster-kubeconfig", mgdKcfg)
 	}
@@ -1086,10 +1093,10 @@ func (r *SpokeReconciler) appendJoinSpokeTransportAndAuthArgs(ctx context.Contex
 	if spoke.Spec.ProxyCa != "" {
 		proxyCaFile, proxyCaCleanup, err := file.TmpFile([]byte(spoke.Spec.ProxyCa), "proxy-ca")
 		if proxyCaCleanup != nil {
-			defer proxyCaCleanup()
+			cleanups = append(cleanups, proxyCaCleanup)
 		}
 		if err != nil {
-			return nil, fmt.Errorf("failed to write proxy CA to disk: %w", err)
+			return nil, cleanup, fmt.Errorf("failed to write proxy CA to disk: %w", err)
 		}
 		joinArgs = append(joinArgs, fmt.Sprintf("--proxy-ca-file=%s", proxyCaFile))
 	}
@@ -1105,7 +1112,7 @@ func (r *SpokeReconciler) appendJoinSpokeTransportAndAuthArgs(ctx context.Contex
 		}
 	}
 
-	return joinArgs, nil
+	return joinArgs, cleanup, nil
 }
 
 // joinSpoke joins a Spoke cluster to the Hub cluster
@@ -1155,7 +1162,10 @@ func (r *SpokeReconciler) joinSpoke(ctx context.Context, spoke *v1beta1.Spoke, h
 	// resources args
 	joinArgs = append(joinArgs, arg_utils.PrepareResources(spoke.Spec.Klusterlet.Resources)...)
 
-	joinArgs, err = r.appendJoinSpokeTransportAndAuthArgs(ctx, joinArgs, spoke, hub, tokenMeta)
+	joinArgs, transportCleanup, err := r.appendJoinSpokeTransportAndAuthArgs(ctx, joinArgs, spoke, hub, tokenMeta)
+	if transportCleanup != nil {
+		defer transportCleanup()
+	}
 	if err != nil {
 		return err
 	}

--- a/fleetconfig-controller/internal/controller/v1beta1/spoke_handler.go
+++ b/fleetconfig-controller/internal/controller/v1beta1/spoke_handler.go
@@ -1013,7 +1013,7 @@ func effectiveGRPCJoinServerAndCA(hub *v1beta1.Hub) (server, ca string, err erro
 // proxy, and addon-kubeclient flags for clusteradm join.
 //
 // Returns (joinArgs, cleanup, err). The cleanup func is always non-nil and removes any temp files written by
-// this call. Callers must defer cleanup() immediatley after this call including on error paths.
+// this call. Callers must defer cleanup() immediately after this call including on error paths.
 func (r *SpokeReconciler) appendJoinSpokeTransportAndAuthArgs(ctx context.Context, joinArgs []string, spoke *v1beta1.Spoke, hub *v1beta1.Hub, tokenMeta *tokenMeta) ([]string, func(), error) {
 	var cleanups []func()
 	cleanup := func() {

--- a/fleetconfig-controller/internal/controller/v1beta1/spoke_handler.go
+++ b/fleetconfig-controller/internal/controller/v1beta1/spoke_handler.go
@@ -1011,6 +1011,9 @@ func effectiveGRPCJoinServerAndCA(hub *v1beta1.Hub) (server, ca string, err erro
 
 // appendJoinSpokeTransportAndAuthArgs appends hub endpoint, hub TLS, registration drivers, hosted-mode kubeconfig,
 // proxy, and addon-kubeclient flags for clusteradm join.
+//
+// Returns (joinArgs, cleanup, err). The cleanup func is always non-nil and removes any temp files written by
+// this call. Callers must defer cleanup() immediatley after this call including on error paths.
 func (r *SpokeReconciler) appendJoinSpokeTransportAndAuthArgs(ctx context.Context, joinArgs []string, spoke *v1beta1.Spoke, hub *v1beta1.Hub, tokenMeta *tokenMeta) ([]string, func(), error) {
 	var cleanups []func()
 	cleanup := func() {

--- a/fleetconfig-controller/internal/controller/v1beta1/spoke_handler_test.go
+++ b/fleetconfig-controller/internal/controller/v1beta1/spoke_handler_test.go
@@ -1,9 +1,16 @@
 package v1beta1
 
 import (
+	"context"
+	"os"
+	"strings"
 	"testing"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	operatorv1 "open-cluster-management.io/api/operator/v1"
+
+	"github.com/open-cluster-management-io/lab/fleetconfig-controller/api/v1alpha1"
+	"github.com/open-cluster-management-io/lab/fleetconfig-controller/api/v1beta1"
 )
 
 func TestSyncManagedClusterAnnotations(t *testing.T) {
@@ -158,6 +165,126 @@ func TestSyncManagedClusterAnnotations(t *testing.T) {
 			for key := range got {
 				if _, ok := tt.want[key]; !ok {
 					t.Errorf("syncManagedClusterAnnotations() has unexpected key %q with value %q", key, got[key])
+				}
+			}
+		})
+	}
+}
+
+// TestAppendJoinSpokeTransportAndAuthArgs_CleanupLifecycle verifies that temp files
+// referenced by --ca-file, --grpc-ca-file, and --proxy-ca-file exist when the helper
+// returns, and are deleted once the returned cleanup func runs.
+func TestAppendJoinSpokeTransportAndAuthArgs_CleanupLifecycle(t *testing.T) {
+	tests := []struct {
+		name      string
+		hub       *v1beta1.Hub
+		spoke     *v1beta1.Spoke
+		wantFlags []string
+	}{
+		{
+			name: "hub CA only",
+			hub: &v1beta1.Hub{
+				Spec: v1beta1.HubSpec{
+					Ca:               "fake-hub-ca",
+					RegistrationAuth: v1beta1.RegistrationAuth{Driver: v1alpha1.CSRRegistrationDriver},
+				},
+			},
+			spoke:     &v1beta1.Spoke{ObjectMeta: metav1.ObjectMeta{Name: "spoke", Namespace: "ns"}},
+			wantFlags: []string{"--ca-file="},
+		},
+		{
+			name: "proxy CA only",
+			hub: &v1beta1.Hub{
+				Spec: v1beta1.HubSpec{
+					RegistrationAuth: v1beta1.RegistrationAuth{Driver: v1alpha1.CSRRegistrationDriver},
+				},
+			},
+			spoke: &v1beta1.Spoke{
+				ObjectMeta: metav1.ObjectMeta{Name: "spoke", Namespace: "ns"},
+				Spec:       v1beta1.SpokeSpec{ProxyCa: "fake-proxy-ca"},
+			},
+			wantFlags: []string{"--proxy-ca-file="},
+		},
+		{
+			name: "hub CA + proxy CA",
+			hub: &v1beta1.Hub{
+				Spec: v1beta1.HubSpec{
+					Ca:               "fake-hub-ca",
+					RegistrationAuth: v1beta1.RegistrationAuth{Driver: v1alpha1.CSRRegistrationDriver},
+				},
+			},
+			spoke: &v1beta1.Spoke{
+				ObjectMeta: metav1.ObjectMeta{Name: "spoke", Namespace: "ns"},
+				Spec:       v1beta1.SpokeSpec{ProxyCa: "fake-proxy-ca"},
+			},
+			wantFlags: []string{"--ca-file=", "--proxy-ca-file="},
+		},
+		{
+			name: "gRPC registration driver",
+			hub: &v1beta1.Hub{
+				Spec: v1beta1.HubSpec{
+					RegistrationAuth: v1beta1.RegistrationAuth{
+						Driver: v1beta1.GRPCRegistrationDriver,
+						GRPC: &v1beta1.RegistrationAuthGRPC{
+							EndpointType: v1beta1.GRPCEndpointTypeHostname,
+							Server:       "grpc.example.com:8090",
+						},
+					},
+				},
+				Status: v1beta1.HubStatus{GRPCServerCA: "fake-grpc-ca"},
+			},
+			spoke:     &v1beta1.Spoke{ObjectMeta: metav1.ObjectMeta{Name: "spoke", Namespace: "ns"}},
+			wantFlags: []string{"--grpc-ca-file="},
+		},
+		{
+			name: "no temp files when nothing to write",
+			hub: &v1beta1.Hub{
+				Spec: v1beta1.HubSpec{
+					RegistrationAuth: v1beta1.RegistrationAuth{Driver: v1alpha1.CSRRegistrationDriver},
+				},
+			},
+			spoke:     &v1beta1.Spoke{ObjectMeta: metav1.ObjectMeta{Name: "spoke", Namespace: "ns"}},
+			wantFlags: nil,
+		},
+	}
+
+	r := &SpokeReconciler{}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			joinArgs, cleanup, err := r.appendJoinSpokeTransportAndAuthArgs(context.Background(), nil, tt.spoke, tt.hub, nil)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if cleanup == nil {
+				t.Fatal("expected non-nil cleanup func")
+			}
+
+			paths := map[string]string{}
+			for _, arg := range joinArgs {
+				for _, flag := range tt.wantFlags {
+					if path, ok := strings.CutPrefix(arg, flag); ok {
+						paths[flag] = path
+					}
+				}
+			}
+			if len(paths) != len(tt.wantFlags) {
+				t.Fatalf("want %d temp file flags %v, got %d: %v", len(tt.wantFlags), tt.wantFlags, len(paths), paths)
+			}
+
+			for flag, path := range paths {
+				if _, err := os.Stat(path); err != nil {
+					t.Errorf("temp file for %s (%s) should exist before cleanup: %v", flag, path, err)
+				}
+			}
+
+			cleanup()
+
+			for flag, path := range paths {
+				_, err := os.Stat(path)
+				if err == nil {
+					t.Errorf("temp file for %s (%s) should be deleted after cleanup but still exists", flag, path)
+				} else if !os.IsNotExist(err) {
+					t.Errorf("unexpected stat error for %s (%s) after cleanup: %v", flag, path, err)
 				}
 			}
 		})


### PR DESCRIPTION
Prior to this fix, if appendJoinSpokeTransportAndAuthArgs created any temp files, they were cleaned up before `clusteradm join` (which references them) runs. This would lead to errors like:

```
clusteradm join command failed for spoke hub-as-spoke: exit status 1, output: Error: open /tmp/ca58134739: no such file or directory
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved temporary resource cleanup during cluster joining operations to ensure artifacts are properly disposed of after setup completion.

* **Tests**
  * Added comprehensive test coverage for temporary resource cleanup lifecycle during join argument construction.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/open-cluster-management-io/lab/pull/194?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->