### PR TITLE
chore: upgrade Go to 1.26.4

### DIFF
--- a/fleetconfig-controller/build/Dockerfile.base
+++ b/fleetconfig-controller/build/Dockerfile.base
@@ -3,7 +3,7 @@
 ARG OS
 ARG ARCH
 
-ARG GO_BASE_IMAGE=golang:1.26.3-alpine3.23
+ARG GO_BASE_IMAGE=golang:1.26.4-alpine3.23
 ARG PYTHON_BASE_IMAGE=python:3.14-alpine
 ARG DISTROLESS_IMAGE=gcr.io/distroless/static:nonroot
 

--- a/fleetconfig-controller/build/Dockerfile.devspace
+++ b/fleetconfig-controller/build/Dockerfile.devspace
@@ -2,7 +2,7 @@ ARG OS
 ARG ARCH
 ARG PROVIDER
 
-ARG GO_BASE_IMAGE=golang:1.26.3-alpine3.23
+ARG GO_BASE_IMAGE=golang:1.26.4-alpine3.23
 
 # Build the manager binary
 FROM ${GO_BASE_IMAGE} AS builder

--- a/fleetconfig-controller/build/Dockerfile.eks
+++ b/fleetconfig-controller/build/Dockerfile.eks
@@ -3,7 +3,7 @@
 ARG OS
 ARG ARCH
 
-ARG GO_BASE_IMAGE=golang:1.26.3-alpine3.23
+ARG GO_BASE_IMAGE=golang:1.26.4-alpine3.23
 ARG PYTHON_BASE_IMAGE=python:3.14-alpine
 ARG DISTROLESS_IMAGE=gcr.io/distroless/static:nonroot
 

--- a/fleetconfig-controller/build/Dockerfile.gke
+++ b/fleetconfig-controller/build/Dockerfile.gke
@@ -3,7 +3,7 @@
 ARG OS
 ARG ARCH
 
-ARG GO_BASE_IMAGE=golang:1.26.3-alpine3.23
+ARG GO_BASE_IMAGE=golang:1.26.4-alpine3.23
 ARG PYTHON_BASE_IMAGE=python:3.14-alpine
 
 ## Stage 1: Build the manager binary

--- a/fleetconfig-controller/go.mod
+++ b/fleetconfig-controller/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-cluster-management-io/lab/fleetconfig-controller
 
-go 1.26.1
+go 1.26.4
 
 require (
 	dario.cat/mergo v1.0.2


### PR DESCRIPTION
Update go.mod directive and all build Dockerfile base images to Go 1.26.4.