### PR TITLE
docs: sync feature gate docs with upstream OCM defaults (fleetconfig-controller)

### DIFF
--- a/fleetconfig-controller/api/v1beta1/hub_types.go
+++ b/fleetconfig-controller/api/v1beta1/hub_types.go
@@ -123,11 +123,14 @@ type Helm struct {
 type ClusterManager struct {
 	// A set of comma-separated pairs of the form 'key1=value1,key2=value2' that describe feature gates for alpha/experimental features.
 	// Options are:
-	//  - AddonManagement (ALPHA - default=true)
+	//  - AddonManagement (BETA - default=true)
 	//  - AllAlpha (ALPHA - default=false)
 	//  - AllBeta (BETA - default=false)
+	//  - CleanUpCompletedManifestWork (ALPHA - default=false)
 	//  - CloudEventsDrivers (ALPHA - default=false)
-	//  - DefaultClusterSet (ALPHA - default=false)
+	//  - ClusterImporter (ALPHA - default=false)
+	//  - ClusterProfile (ALPHA - default=false)
+	//  - DefaultClusterSet (ALPHA - default=true)
 	//  - ManagedClusterAutoApproval (ALPHA - default=false)
 	//  - ManifestWorkReplicaSet (ALPHA - default=false)
 	//  - NilExecutorValidating (ALPHA - default=false)

--- a/fleetconfig-controller/api/v1beta1/spoke_types.go
+++ b/fleetconfig-controller/api/v1beta1/spoke_types.go
@@ -180,11 +180,13 @@ type Klusterlet struct {
 
 	// A set of comma-separated pairs of the form 'key1=value1,key2=value2' that describe feature gates for alpha/experimental features.
 	// Options are:
-	//  - AddonManagement (ALPHA - default=true)
+	//  - AddonManagement (BETA - default=true)
 	//  - AllAlpha (ALPHA - default=false)
 	//  - AllBeta (BETA - default=false)
-	//  - ClusterClaim (ALPHA - default=true)
+	//  - ClusterClaim (BETA - default=true)
+	//  - ClusterProperty (ALPHA - default=false)
 	//  - ExecutorValidatingCaches (ALPHA - default=false)
+	//  - MultipleHubs (ALPHA - default=false)
 	//  - RawFeedbackJsonString (ALPHA - default=false)
 	//  - V1beta1CSRAPICompatibility (ALPHA - default=false)
 	// +kubebuilder:default:="AddonManagement=true,ClusterClaim=true"

--- a/fleetconfig-controller/charts/fleetconfig-controller/README.md
+++ b/fleetconfig-controller/charts/fleetconfig-controller/README.md
@@ -37,11 +37,13 @@ Uncomment and configure `fleetConfig.spokeFeatureGates` to enable feature gates 
 Do not disable the feature gates that are enabled by default.
 
 Available Spoke Feature Gates:
-- **AddonManagement** (ALPHA - default=true) - Enables addon management functionality
+- **AddonManagement** (BETA - default=true) - Enables addon management functionality
 - **AllAlpha** (ALPHA - default=false) - Enables all alpha features
 - **AllBeta** (BETA - default=false) - Enables all beta features
-- **ClusterClaim** (ALPHA - default=true) - Enables cluster claim functionality
+- **ClusterClaim** (BETA - default=true) - Enables cluster claim functionality
+- **ClusterProperty** (ALPHA - default=false) - Enables cluster property functionality
 - **ExecutorValidatingCaches** (ALPHA - default=false) - Enables executor validating caches
+- **MultipleHubs** (ALPHA - default=false) - Enables multiple bootstrap kubeconfigs connecting to different hubs
 - **RawFeedbackJsonString** (ALPHA - default=false) - Enables raw feedback JSON string support
 - **V1beta1CSRAPICompatibility** (ALPHA - default=false) - Enables v1beta1 CSR API compatibility
 ### Registration Authentication Configuration
@@ -54,11 +56,13 @@ Available fields:
 Feature gates for the Hub's Cluster Manager. Do not disable the feature gates that are enabled by default.
 
 Available Hub Cluster Manager Feature Gates:
-- **AddonManagement** (ALPHA - default=true) - Enables addon management functionality
+- **AddonManagement** (BETA - default=true) - Enables addon management functionality
 - **AllAlpha** (ALPHA - default=false) - Enables all alpha features
 - **AllBeta** (BETA - default=false) - Enables all beta features
 - **CloudEventsDrivers** (ALPHA - default=false) - Enables cloud events drivers
-- **DefaultClusterSet** (ALPHA - default=false) - Enables default cluster set functionality
+- **ClusterImporter** (ALPHA - default=false) - Enables auto import of managed clusters for certain cluster providers
+- **ClusterProfile** (ALPHA - default=false) - Enables syncing of ManagedCluster to ClusterProfile
+- **DefaultClusterSet** (ALPHA - default=true) - Enables default cluster set functionality
 - **ManagedClusterAutoApproval** (ALPHA - default=false) - Enables automatic managed cluster approval
 - **ManifestWorkReplicaSet** (ALPHA - default=false) - Enables manifest work replica set functionality
 - **NilExecutorValidating** (ALPHA - default=false) - Enables nil executor validation
@@ -90,7 +94,7 @@ Resource specifications for all klusterlet-managed containers.
 | `fleetConfig.timeout`                                                                     | Timeout in seconds for all clusteradm operations, including init, accept, join, upgrade, etc.                                                                                                                                                                                                                                                                                                                                                                                                         | `300`                             |
 | `fleetConfig.logVerbosity`                                                                | Log verbosity. Valid values: 0-10, 0 is the least verbose, 10 is the most verbose.                                                                                                                                                                                                                                                                                                                                                                                                                    | `0`                               |
 | `fleetConfig.spokeAnnotations`                                                            | Global annotations to apply to all spoke clusters. If not present, the 'agent.open-cluster-management.io/' prefix is added to each key. Each annotation is added to klusterlet.spec.registrationConfiguration.clusterAnnotations on every spoke and subsequently to the ManagedClusters on the hub. Per-spoke annotations take precedence over the global annotations.                                                                                                                                | `{}`                              |
-| `fleetConfig.spokeFeatureGates.ClusterClaim`                                              | ClusterClaim feature gate (ALPHA - default=true). Enables cluster claim functionality.                                                                                                                                                                                                                                                                                                                                                                                                                | `true`                            |
+| `fleetConfig.spokeFeatureGates.ClusterClaim`                                              | ClusterClaim feature gate (BETA - default=true). Enables cluster claim functionality.                                                                                                                                                                                                                                                                                                                                                                                                                 | `true`                            |
 | `fleetConfig.spokeFeatureGates.RawFeedbackJsonString`                                     | RawFeedbackJsonString feature gate (ALPHA - default=false). Enables raw feedback JSON string support.                                                                                                                                                                                                                                                                                                                                                                                                 | `true`                            |
 | `fleetConfig.source.bundleVersion`                                                        | Bundle version.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       | `v1.3.1`                          |
 | `fleetConfig.source.registry`                                                             | Image registry.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       | `quay.io/open-cluster-management` |

--- a/fleetconfig-controller/charts/fleetconfig-controller/crds/fleetconfig.open-cluster-management.io_hubs.yaml
+++ b/fleetconfig-controller/charts/fleetconfig-controller/crds/fleetconfig.open-cluster-management.io_hubs.yaml
@@ -93,11 +93,14 @@ spec:
                     description: |-
                       A set of comma-separated pairs of the form 'key1=value1,key2=value2' that describe feature gates for alpha/experimental features.
                       Options are:
-                       - AddonManagement (ALPHA - default=true)
+                       - AddonManagement (BETA - default=true)
                        - AllAlpha (ALPHA - default=false)
                        - AllBeta (BETA - default=false)
+                       - CleanUpCompletedManifestWork (ALPHA - default=false)
                        - CloudEventsDrivers (ALPHA - default=false)
-                       - DefaultClusterSet (ALPHA - default=false)
+                       - ClusterImporter (ALPHA - default=false)
+                       - ClusterProfile (ALPHA - default=false)
+                       - DefaultClusterSet (ALPHA - default=true)
                        - ManagedClusterAutoApproval (ALPHA - default=false)
                        - ManifestWorkReplicaSet (ALPHA - default=false)
                        - NilExecutorValidating (ALPHA - default=false)

--- a/fleetconfig-controller/charts/fleetconfig-controller/crds/fleetconfig.open-cluster-management.io_spokes.yaml
+++ b/fleetconfig-controller/charts/fleetconfig-controller/crds/fleetconfig.open-cluster-management.io_spokes.yaml
@@ -395,11 +395,13 @@ spec:
                     description: |-
                       A set of comma-separated pairs of the form 'key1=value1,key2=value2' that describe feature gates for alpha/experimental features.
                       Options are:
-                       - AddonManagement (ALPHA - default=true)
+                       - AddonManagement (BETA - default=true)
                        - AllAlpha (ALPHA - default=false)
                        - AllBeta (BETA - default=false)
-                       - ClusterClaim (ALPHA - default=true)
+                       - ClusterClaim (BETA - default=true)
+                       - ClusterProperty (ALPHA - default=false)
                        - ExecutorValidatingCaches (ALPHA - default=false)
+                       - MultipleHubs (ALPHA - default=false)
                        - RawFeedbackJsonString (ALPHA - default=false)
                        - V1beta1CSRAPICompatibility (ALPHA - default=false)
                     type: string

--- a/fleetconfig-controller/charts/fleetconfig-controller/values.yaml
+++ b/fleetconfig-controller/charts/fleetconfig-controller/values.yaml
@@ -22,16 +22,18 @@ fleetConfig:
   ## Do not disable the feature gates that are enabled by default.
   ##
   ## Available Spoke Feature Gates:
-  ## - **AddonManagement** (ALPHA - default=true) - Enables addon management functionality
+  ## - **AddonManagement** (BETA - default=true) - Enables addon management functionality
   ## - **AllAlpha** (ALPHA - default=false) - Enables all alpha features
   ## - **AllBeta** (BETA - default=false) - Enables all beta features
-  ## - **ClusterClaim** (ALPHA - default=true) - Enables cluster claim functionality
+  ## - **ClusterClaim** (BETA - default=true) - Enables cluster claim functionality
+  ## - **ClusterProperty** (ALPHA - default=false) - Enables cluster property functionality
   ## - **ExecutorValidatingCaches** (ALPHA - default=false) - Enables executor validating caches
+  ## - **MultipleHubs** (ALPHA - default=false) - Enables multiple bootstrap kubeconfigs connecting to different hubs
   ## - **RawFeedbackJsonString** (ALPHA - default=false) - Enables raw feedback JSON string support
   ## - **V1beta1CSRAPICompatibility** (ALPHA - default=false) - Enables v1beta1 CSR API compatibility
   ## @descriptionEnd
   spokeFeatureGates:
-    ## @param fleetConfig.spokeFeatureGates.ClusterClaim ClusterClaim feature gate (ALPHA - default=true). Enables cluster claim functionality.
+    ## @param fleetConfig.spokeFeatureGates.ClusterClaim ClusterClaim feature gate (BETA - default=true). Enables cluster claim functionality.
     ClusterClaim: true
     ## @param fleetConfig.spokeFeatureGates.RawFeedbackJsonString RawFeedbackJsonString feature gate (ALPHA - default=false). Enables raw feedback JSON string support.
     RawFeedbackJsonString: true
@@ -82,11 +84,13 @@ fleetConfig:
       ## Feature gates for the Hub's Cluster Manager. Do not disable the feature gates that are enabled by default.
       ##
       ## Available Hub Cluster Manager Feature Gates:
-      ## - **AddonManagement** (ALPHA - default=true) - Enables addon management functionality
+      ## - **AddonManagement** (BETA - default=true) - Enables addon management functionality
       ## - **AllAlpha** (ALPHA - default=false) - Enables all alpha features
       ## - **AllBeta** (BETA - default=false) - Enables all beta features
       ## - **CloudEventsDrivers** (ALPHA - default=false) - Enables cloud events drivers
-      ## - **DefaultClusterSet** (ALPHA - default=false) - Enables default cluster set functionality
+      ## - **ClusterImporter** (ALPHA - default=false) - Enables auto import of managed clusters for certain cluster providers
+      ## - **ClusterProfile** (ALPHA - default=false) - Enables syncing of ManagedCluster to ClusterProfile
+      ## - **DefaultClusterSet** (ALPHA - default=true) - Enables default cluster set functionality
       ## - **ManagedClusterAutoApproval** (ALPHA - default=false) - Enables automatic managed cluster approval
       ## - **ManifestWorkReplicaSet** (ALPHA - default=false) - Enables manifest work replica set functionality
       ## - **NilExecutorValidating** (ALPHA - default=false) - Enables nil executor validation


### PR DESCRIPTION
Thank you for maintaining an awesome project!
Since this is my first contribution to this project, please let me know and I'll be happy to fix it if I've missed something 🙏 

## Summary

The documented feature gate stages/defaults in the v1beta1 API and the Helm chart have drifted from the actual defaults defined upstream in [`open-cluster-management.io/api/feature`](https://github.com/open-cluster-management-io/api/blob/main/feature/feature.go).

This PR refreshes them:
- **AddonManagement** and **ClusterClaim** are documented as ALPHA but have been promoted to BETA upstream.
- **DefaultClusterSet** is documented as `default=false` but defaults to `true` upstream.
- Several gates were missing from the documented lists:
  - Hub (Cluster Manager): `CleanUpCompletedManifestWork`, `ClusterImporter`, `ClusterProfile`
  - Spoke (Klusterlet): `ClusterProperty`, `MultipleHubs`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated feature gate documentation to reflect current maturity levels, including Beta status for `AddonManagement`, `ClusterClaim`, and `DefaultClusterSet`.
  * Documented additional Hub and Spoke feature gates, including cluster importing, profiles, properties, multiple hubs, and validating caches.
  * Updated the default for `DefaultClusterSet` to enabled in the documented configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->