### PR TITLE
fix: stop defaulting featureGates and omit --feature-gates when unset

### DIFF
--- a/fleetconfig-controller/api/v1beta1/hub_types.go
+++ b/fleetconfig-controller/api/v1beta1/hub_types.go
@@ -122,6 +122,9 @@ type Helm struct {
 // ClusterManager is the configuration for a cluster manager.
 type ClusterManager struct {
 	// A set of comma-separated pairs of the form 'key1=value1,key2=value2' that describe feature gates for alpha/experimental features.
+	// Only the gates listed here are configured explicitly on the cluster manager. Any gate that is
+	// omitted falls back to the default of the OCM version in use, so gates marked default=true below
+	// are enabled even when this field is empty.
 	// Options are:
 	//  - AddonManagement (BETA - default=true)
 	//  - AllAlpha (ALPHA - default=false)
@@ -136,7 +139,6 @@ type ClusterManager struct {
 	//  - NilExecutorValidating (ALPHA - default=false)
 	//  - ResourceCleanup (BETA - default=true)
 	//  - V1beta1CSRAPICompatibility (ALPHA - default=false)
-	// +kubebuilder:default:="AddonManagement=true"
 	// +optional
 	FeatureGates string `json:"featureGates,omitempty"`
 

--- a/fleetconfig-controller/api/v1beta1/spoke_types.go
+++ b/fleetconfig-controller/api/v1beta1/spoke_types.go
@@ -179,6 +179,9 @@ type Klusterlet struct {
 	Annotations map[string]string `json:"annotations,omitempty"`
 
 	// A set of comma-separated pairs of the form 'key1=value1,key2=value2' that describe feature gates for alpha/experimental features.
+	// Only the gates listed here are configured explicitly on the klusterlet. Any gate that is
+	// omitted falls back to the default of the OCM version in use, so gates marked default=true below
+	// are enabled even when this field is empty.
 	// Options are:
 	//  - AddonManagement (BETA - default=true)
 	//  - AllAlpha (ALPHA - default=false)
@@ -189,7 +192,6 @@ type Klusterlet struct {
 	//  - MultipleHubs (ALPHA - default=false)
 	//  - RawFeedbackJsonString (ALPHA - default=false)
 	//  - V1beta1CSRAPICompatibility (ALPHA - default=false)
-	// +kubebuilder:default:="AddonManagement=true,ClusterClaim=true"
 	// +optional
 	FeatureGates string `json:"featureGates,omitempty"`
 

--- a/fleetconfig-controller/charts/fleetconfig-controller/crds/fleetconfig.open-cluster-management.io_hubs.yaml
+++ b/fleetconfig-controller/charts/fleetconfig-controller/crds/fleetconfig.open-cluster-management.io_hubs.yaml
@@ -89,9 +89,11 @@ spec:
                 description: ClusterManager configuration.
                 properties:
                   featureGates:
-                    default: AddonManagement=true
                     description: |-
                       A set of comma-separated pairs of the form 'key1=value1,key2=value2' that describe feature gates for alpha/experimental features.
+                      Only the gates listed here are configured explicitly on the cluster manager. Any gate that is
+                      omitted falls back to the default of the OCM version in use, so gates marked default=true below
+                      are enabled even when this field is empty.
                       Options are:
                        - AddonManagement (BETA - default=true)
                        - AllAlpha (ALPHA - default=false)

--- a/fleetconfig-controller/charts/fleetconfig-controller/crds/fleetconfig.open-cluster-management.io_spokes.yaml
+++ b/fleetconfig-controller/charts/fleetconfig-controller/crds/fleetconfig.open-cluster-management.io_spokes.yaml
@@ -391,9 +391,11 @@ spec:
                       Each annotation is added to klusterlet.spec.registrationConfiguration.clusterAnnotations on the spoke and subsequently to the ManagedCluster on the hub.
                     type: object
                   featureGates:
-                    default: AddonManagement=true,ClusterClaim=true
                     description: |-
                       A set of comma-separated pairs of the form 'key1=value1,key2=value2' that describe feature gates for alpha/experimental features.
+                      Only the gates listed here are configured explicitly on the klusterlet. Any gate that is
+                      omitted falls back to the default of the OCM version in use, so gates marked default=true below
+                      are enabled even when this field is empty.
                       Options are:
                        - AddonManagement (BETA - default=true)
                        - AllAlpha (ALPHA - default=false)

--- a/fleetconfig-controller/internal/controller/v1beta1/hub_controller.go
+++ b/fleetconfig-controller/internal/controller/v1beta1/hub_controller.go
@@ -547,7 +547,10 @@ func (r *HubReconciler) initializeHub(ctx context.Context, hub *v1beta1.Hub, hub
 		}
 	} else if hub.Spec.ClusterManager != nil {
 		// clustermanager args
-		initArgs = append(initArgs, "--feature-gates", hub.Spec.ClusterManager.FeatureGates)
+		// Omit --feature-gates entirely when no gates are specified.
+		if hub.Spec.ClusterManager.FeatureGates != "" {
+			initArgs = append(initArgs, "--feature-gates", hub.Spec.ClusterManager.FeatureGates)
+		}
 		initArgs = append(initArgs, fmt.Sprintf("--use-bootstrap-token=%t", hub.Spec.ClusterManager.UseBootstrapToken))
 		// source args
 		initArgs = append(initArgs, "--bundle-version", hub.Spec.ClusterManager.Source.BundleVersion)

--- a/fleetconfig-controller/internal/controller/v1beta1/spoke_handler.go
+++ b/fleetconfig-controller/internal/controller/v1beta1/spoke_handler.go
@@ -1251,10 +1251,14 @@ func (r *SpokeReconciler) joinSpoke(ctx context.Context, spoke *v1beta1.Spoke, m
 		"--wait=true",
 		// klusterlet args
 		"--mode", spoke.Spec.Klusterlet.Mode,
-		"--feature-gates", spoke.Spec.Klusterlet.FeatureGates,
 		fmt.Sprintf("--force-internal-endpoint-lookup=%t", spoke.Spec.Klusterlet.ForceInternalEndpointLookup),
 		fmt.Sprintf("--singleton=%t", spoke.Spec.Klusterlet.Singleton),
 	}, spoke.BaseArgs()...)
+
+	// Omit --feature-gates entirely when no gates are specified.
+	if spoke.Spec.Klusterlet.FeatureGates != "" {
+		joinArgs = append(joinArgs, "--feature-gates", spoke.Spec.Klusterlet.FeatureGates)
+	}
 
 	if hub.Spec.ClusterManager != nil {
 		// source args


### PR DESCRIPTION
## Summary

The `featureGates` fields on `Hub.spec.clusterManager` and `Spoke.spec.klusterlet` previously had hardcoded kubebuilder defaults. This PR makes the OCM version's own defaults the source of truth:

- Remove the `+kubebuilder:default` markers from `ClusterManager.FeatureGates` and `Klusterlet.FeatureGates` (CRDs regenerated via `make manifests`).
- Skip the `--feature-gates` flag entirely in `initializeHub` / `joinSpoke` when the field is empty, so the cluster manager / klusterlet fall back to the defaults of the installed OCM version.
- Update the field docs to clarify that only explicitly listed gates are configured, and that omitted gates (including ones marked `default=true`) still follow OCM's defaults.

## Behavior change

Users who relied on the CRD default being written into their resources are unaffected as long as they didn't need to override it: an empty `featureGates` now yields the same effective gates via OCM's own defaults. Explicitly set values behave exactly as before.

## Test

- [x] `make manifests` produces no further diff.
- [x] `make test-unit` passes all tests.
- [x] `make test-e2e` passes all tests.
- [x] Hub init without `featureGates` → no `--feature-gates` in clusteradm args, default gates active
- [x] Spoke join without `featureGates` → same as above
- [x] Explicit `featureGates` values are still passed through unchanged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Feature gates for cluster managers and klusterlets now use the OCM version’s defaults when none are explicitly configured.
  * Explicitly configured feature gates continue to be applied during hub initialization and spoke joining.
  * Empty feature-gate settings no longer pass unnecessary configuration arguments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->