### PR TITLE
fix: add managedclustersets/bind RBAC for topology resources (fleetconfig-controller)

### DIFF
--- a/fleetconfig-controller/charts/fleetconfig-controller/templates/rbac/manager-rbac.yaml
+++ b/fleetconfig-controller/charts/fleetconfig-controller/templates/rbac/manager-rbac.yaml
@@ -133,6 +133,10 @@ rules:
   resources: ["managedclustersets/join"]
   verbs: ["create"]
 - apiGroups: ["cluster.open-cluster-management.io"]
+  resources: ["managedclustersets/bind"]
+  resourceNames: ["default", "global", "spokes"]
+  verbs: ["create"]
+- apiGroups: ["cluster.open-cluster-management.io"]
   resources:
   - "addonplacementscores"
   - "managedclustersetbindings"

--- a/fleetconfig-controller/test/e2e/v1beta1_hub_spoke.go
+++ b/fleetconfig-controller/test/e2e/v1beta1_hub_spoke.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"strings"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -31,6 +32,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ktypes "k8s.io/apimachinery/pkg/types"
 	addonv1alpha1 "open-cluster-management.io/api/addon/v1alpha1"
+	clusterv1beta2 "open-cluster-management.io/api/cluster/v1beta2"
 	operatorv1 "open-cluster-management.io/api/operator/v1"
 	"open-cluster-management.io/ocm/pkg/operator/helpers/chart"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -99,6 +101,75 @@ var _ = Describe("hub and spoke", Label("v1beta1"), Serial, Ordered, func() {
 			Expect(err).NotTo(HaveOccurred())
 			err = utils.CloneSpoke(hubAsSpoke, hubAsSpokeClone)
 			Expect(err).NotTo(HaveOccurred())
+		})
+
+		// On a fresh install the topology resources are created before the clustermanager's
+		// webhook exists, so a missing managedclustersets/bind RBAC rule goes undetected.
+		// The bindings must be deleted before the restart: CreateOrUpdate skips no-op writes,
+		// so recreating them is the only way to exercise the live webhook.
+		It("should recreate topology resources when the controller restarts after the hub is running", func() {
+			bindings := []ktypes.NamespacedName{
+				{Name: v1beta1.ManagedClusterSetGlobal, Namespace: v1beta1.NamespaceManagedClusterSetGlobal},
+				{Name: v1beta1.ManagedClusterSetDefault, Namespace: v1beta1.NamespaceManagedClusterSetDefault},
+				{Name: v1beta1.ManagedClusterSetSpokes, Namespace: v1beta1.NamespaceManagedClusterSetSpokes},
+			}
+
+			// The addon agent Deployments also carry the control-plane=controller-manager label.
+			managerDeployment := &appsv1.Deployment{}
+			deployments := &appsv1.DeploymentList{}
+			Expect(tc.kClient.List(tc.ctx, deployments, client.InNamespace(fcNamespace),
+				client.MatchingLabels{"control-plane": "controller-manager"})).To(Succeed())
+			for i := range deployments.Items {
+				if strings.HasSuffix(deployments.Items[i].Name, "-manager") {
+					managerDeployment = &deployments.Items[i]
+					break
+				}
+			}
+			Expect(managerDeployment.Name).NotTo(BeEmpty(), "no controller-manager deployment found in namespace "+fcNamespace)
+
+			By("deleting the ManagedClusterSetBindings created at startup")
+			for _, nn := range bindings {
+				binding := &clusterv1beta2.ManagedClusterSetBinding{
+					ObjectMeta: metav1.ObjectMeta{Name: nn.Name, Namespace: nn.Namespace},
+				}
+				err := tc.kClient.Delete(tc.ctx, binding)
+				Expect(client.IgnoreNotFound(err)).NotTo(HaveOccurred())
+			}
+
+			By("restarting the fleetconfig-controller manager")
+			if managerDeployment.Spec.Template.Annotations == nil {
+				managerDeployment.Spec.Template.Annotations = map[string]string{}
+			}
+			managerDeployment.Spec.Template.Annotations["fleetconfig.test/restartedAt"] = time.Now().Format(time.RFC3339)
+			Expect(tc.kClient.Update(tc.ctx, managerDeployment)).To(Succeed())
+
+			By("verifying the restarted manager recreates all ManagedClusterSetBindings")
+			Eventually(func() error {
+				for _, nn := range bindings {
+					binding := &clusterv1beta2.ManagedClusterSetBinding{}
+					if err := tc.kClient.Get(tc.ctx, nn, binding); err != nil {
+						return fmt.Errorf("ManagedClusterSetBinding %s not recreated: %w", nn, err)
+					}
+				}
+				return nil
+			}, 5*time.Minute, 5*time.Second).Should(Succeed())
+
+			By("verifying the manager deployment becomes available again")
+			Eventually(func() error {
+				d := &appsv1.Deployment{}
+				if err := tc.kClient.Get(tc.ctx, client.ObjectKeyFromObject(managerDeployment), d); err != nil {
+					return err
+				}
+				wantReplicas := int32(1)
+				if d.Spec.Replicas != nil {
+					wantReplicas = *d.Spec.Replicas
+				}
+				if d.Status.UpdatedReplicas != wantReplicas || d.Status.AvailableReplicas != wantReplicas {
+					return fmt.Errorf("deployment %s not fully rolled out: %d/%d updated, %d/%d available",
+						d.Name, d.Status.UpdatedReplicas, wantReplicas, d.Status.AvailableReplicas, wantReplicas)
+				}
+				return nil
+			}, 5*time.Minute, 5*time.Second).Should(Succeed())
 		})
 
 		It("should verify addons configured on the hub and enabled on the spoke", func() {

--- a/fleetconfig-controller/test/e2e/v1beta1_hub_spoke.go
+++ b/fleetconfig-controller/test/e2e/v1beta1_hub_spoke.go
@@ -164,9 +164,13 @@ var _ = Describe("hub and spoke", Label("v1beta1"), Serial, Ordered, func() {
 				if d.Spec.Replicas != nil {
 					wantReplicas = *d.Spec.Replicas
 				}
-				if d.Status.UpdatedReplicas != wantReplicas || d.Status.AvailableReplicas != wantReplicas {
-					return fmt.Errorf("deployment %s not fully rolled out: %d/%d updated, %d/%d available",
-						d.Name, d.Status.UpdatedReplicas, wantReplicas, d.Status.AvailableReplicas, wantReplicas)
+				if d.Status.ObservedGeneration < d.Generation {
+					return fmt.Errorf("deployment %s not observed: generation %d, observed %d",
+						d.Name, d.Generation, d.Status.ObservedGeneration)
+				}
+				if d.Status.Replicas != wantReplicas || d.Status.UpdatedReplicas != wantReplicas || d.Status.AvailableReplicas != wantReplicas {
+					return fmt.Errorf("deployment %s not fully rolled out: %d replicas, %d updated, %d available (want %d)",
+						d.Name, d.Status.Replicas, d.Status.UpdatedReplicas, d.Status.AvailableReplicas, wantReplicas)
 				}
 				return nil
 			}, 5*time.Minute, 5*time.Second).Should(Succeed())


### PR DESCRIPTION
### Summary

The manager crashed at startup because OCM's ManagedClusterSetBinding validating webhook denied the topology resource creation: the `SubjectAccessReview` on `managedclustersets/bind` failed for the `fleetconfig-controller-manager` ServiceAccount. Added the missing `managedclustersets/bind` (create) rule to the manager ClusterRole, scoped to the `default`, `global`, and `spokes` cluster sets.

### How to reproduce

1. Deploy fleetconfig-controller with `fleetConfig.enabled: false`
2. Create a Hub CR in namespace A
3. Recreate the Hub CR in namespace B (deleting the Hub runs `clusteradm clean`, which removes the hub CRDs and garbage-collects the ManagedClusterSetBindings; recreating it brings the webhook back, but not the bindings)
4. Restart the controller pod → it fails to recreate the bindings through the now-live webhook and enters CrashLoopBackOff

### Testing

- [x] `make test-e2e` passes with the new spec included.
- [x] `helm template` / `helm lint` pass.
- [x] Verified on a real cluster: applying new ClusterRole / ClusterRoleBinding recovered the controller from CrashLoopBackOff to Running.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recovery after a controller restart by recreating required cluster topology bindings.
  * Ensured the controller can establish the necessary permissions for cluster set binding operations.
  * Improved rollout reliability by confirming updated and available controller replicas before reporting recovery complete.

* **Tests**
  * Added end-to-end coverage verifying topology resources are recreated and the controller becomes fully available after restart.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->